### PR TITLE
Several fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Apio package that contains the [icesprog programmer](https://github.com/wuxx/ice
 
 ## build instructions
 
-On *Ubuntu 18.04.5 LTS*
+Tested on *Ubuntu 20.04 LTS*
 
 ```
 sudo apt install git && git clone https://github.com/FPGAwars/toolchain-icesprog.git
@@ -15,17 +15,6 @@ cd toolchain-icesprog
 ```
 
 Other target platforms may work in the future.
-
-On *Ubuntu 16.04.6 LTS on WSL2*
-
-```
-sudo apt install git && git clone https://github.com/FPGAwars/toolchain-icesprog.git
-cd toolchain-icesprog
-# ./build.sh linux_i686 # Not working!!
-./build.sh linux_x86_64 
-./build.sh windows_x86
-./build.sh windows_amd64
-```
 
 ## Credits
 

--- a/scripts/build_setup.sh
+++ b/scripts/build_setup.sh
@@ -10,19 +10,22 @@ fi
 if [ "$ARCH" == "linux_i686" ]; then
   export CC="gcc -m32"
   export HOST="i686-linux-gnu"
-  export CONFIG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32"
+  export LIBHIDAPI_NAME="hidapi-libusb"
+  # export CONFIG_FLAGS="CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32"
   export CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=$WORK_DIR/build-data/cmake/toolchain-m32.cmake"
 fi
 
 if [ "$ARCH" == "linux_armv7l" ]; then
   export CC="arm-linux-gnueabihf-gcc"
   export HOST="arm-linux-gnueabihf"
+  export LIBHIDAPI_NAME="hidapi-libusb"
   export CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=$WORK_DIR/build-data/cmake/toolchain-armhf.cmake"
 fi
 
 if [ "$ARCH" == "linux_aarch64" ]; then
   export CC="aarch64-linux-gnu-gcc"
   export HOST="aarch64-linux-gnu"
+  export LIBHIDAPI_NAME="hidapi-libusb"
   export CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=$WORK_DIR/build-data/cmake/toolchain-aarch64.cmake"
 fi
 
@@ -30,7 +33,9 @@ if [ "$ARCH" == "windows_x86" ]; then
   export EXE=".exe"
   export CC="i686-w64-mingw32-gcc"
   export HOST="i686-w64-mingw32"
+  export LIBHIDAPI_NAME="hidapi"
   export CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=$WORK_DIR/build-data/cmake/toolchain-win32.cmake"
+  export EXTRA_LIB="-lsetupapi -lhid"
 fi
 
 if [ "$ARCH" == "windows_amd64" ]; then

--- a/scripts/compile_hidapi.sh
+++ b/scripts/compile_hidapi.sh
@@ -3,7 +3,10 @@
 # -- Compile hidapi script
 LIBHIDAPI_VER=0.9.0
 LIBHIDAPI="hidapi-$LIBHIDAPI_VER"
-export LIBHIDAPI_FOLDER="hidapi-$LIBHIDAPI"
+LIBUSB_VER=1.0.22
+LIBUSB=libusb-$LIBUSB_VER
+
+LIBHIDAPI_FOLDER="hidapi-$LIBHIDAPI"
 TAR_LIBHIDAPI="$LIBHIDAPI.tar.gz"
 REL_LIBHIDAPI="https://github.com/libusb/hidapi/archive/$TAR_LIBHIDAPI"
 
@@ -38,15 +41,19 @@ fi
 echo ""
 echo "----------> COMPILAR EJEMPLO!!!!"
 
+
+if [ "$ARCH" == "windows_x86" ]; then
+  EXTRA_LIB=" -lhid -lsetupapi"
+fi
+
 #-- Build hidtest statically linked
 cd hidtest || exit
 test -f "hidtest$EXE" && rm "hidtest$EXE"
 if [ "$ARCH" == "darwin" ]; then
   # TODO
-  $CC -o hidtest hidtest.cpp -lusb-1.0 -I../hidtest
+  $CC -o hidtest hidtest.cpp -lusb-1.0 -lhidapi -I../hidtest
 else
-  echo " $CC -o hidtest$EXE hidtest.cpp -static -L$PREFIX/lib -I$PREFIX/include/hidapi -lhidapi-libusb -L$BUILD_DIR/$LIBUSB/release/lib -lusb-1.0 -lpthread $EXTRA_LIB" 
-  $CC -o "hidtest$EXE" hidtest.cpp -static -L"$PREFIX"/lib -I"$PREFIX"/include/hidapi -l$LIBHIDAPI_NAME -L"$BUILD_DIR/$LIBUSB"/release/lib -lusb-1.0 -lpthread $EXTRA_LIB
+  $CC -o "hidtest$EXE" hidtest.cpp -static -L"$PREFIX"/lib -I"$PREFIX"/include/hidapi -lhidapi -L"$BUILD_DIR/$LIBUSB"/release/lib -lusb-1.0 -lpthread $EXTRA_LIB
 fi
 cd ..
 

--- a/scripts/compile_hidapi.sh
+++ b/scripts/compile_hidapi.sh
@@ -53,7 +53,7 @@ if [ "$ARCH" == "darwin" ]; then
   # TODO
   $CC -o hidtest hidtest.cpp -lusb-1.0 -lhidapi -I../hidtest
 else
-  $CC -o "hidtest$EXE" hidtest.cpp -static -L"$PREFIX"/lib -I"$PREFIX"/include/hidapi -lhidapi -L"$BUILD_DIR/$LIBUSB"/release/lib -lusb-1.0 -lpthread $EXTRA_LIB
+  $CC -o "hidtest$EXE" hidtest.cpp -static -L"$PREFIX"/lib -I"$PREFIX"/include/hidapi -l$LIBHIDAPI_NAME -L"$BUILD_DIR/$LIBUSB"/release/lib -lusb-1.0 -lpthread $EXTRA_LIB
 fi
 cd ..
 

--- a/scripts/compile_hidapi.sh
+++ b/scripts/compile_hidapi.sh
@@ -3,8 +3,10 @@
 # -- Compile hidapi script
 LIBHIDAPI_VER=0.9.0
 LIBHIDAPI="hidapi-$LIBHIDAPI_VER"
-LIBUSB_VER=1.0.22
-LIBUSB=libusb-$LIBUSB_VER
+
+# -- This vars are inherited from compile_lsusb.sh but you will need them here if you disable it's COMPILE_LSUSB flag
+# LIBUSB_VER=1.0.22
+# LIBUSB=libusb-$LIBUSB_VER
 
 LIBHIDAPI_FOLDER="hidapi-$LIBHIDAPI"
 TAR_LIBHIDAPI="$LIBHIDAPI.tar.gz"
@@ -41,10 +43,6 @@ fi
 echo ""
 echo "----------> COMPILAR EJEMPLO!!!!"
 
-
-if [ "$ARCH" == "windows_x86" ]; then
-  EXTRA_LIB=" -lhid -lsetupapi"
-fi
 
 #-- Build hidtest statically linked
 cd hidtest || exit

--- a/scripts/compile_icesprog.sh
+++ b/scripts/compile_icesprog.sh
@@ -37,7 +37,7 @@ cd "$BUILD_DIR/icesprog" || exit
 PREFIX_LIBHIDAPI="$BUILD_DIR/$LIBHIDAPI_FOLDER/release"
 PREFIX_LIBUSB="$BUILD_DIR/$LIBUSB"/release
 
-wget "$WINDOWSBINMODE_URL" -O binmode.cwget
+wget "$WINDOWSBINMODE_URL" -O binmode.c
 
 if [ "$ARCH" == "darwin" ]; then
   # TODO

--- a/scripts/compile_icesprog.sh
+++ b/scripts/compile_icesprog.sh
@@ -8,6 +8,9 @@ ICESUGAR="icesugar"
 # -- Trusted tag or commit
 SRC_TAG="6424e0d8f8a48fe0bd77059bbc0fa9bf72767708"
 
+# -- Binmode source so windows build open files as binary without source change
+WINDOWSBINMODE_URL="https://raw.githubusercontent.com/aalku/mingw-w64-binmode/74de4252e605a2fb82a526a8befc79f4152a7819/binmode.c"
+
 # -- Setup
 # shellcheck source=scripts/build_setup.sh
 . "$WORK_DIR"/scripts/build_setup.sh
@@ -34,22 +37,15 @@ cd "$BUILD_DIR/icesprog" || exit
 PREFIX_LIBHIDAPI="$BUILD_DIR/$LIBHIDAPI_FOLDER/release"
 PREFIX_LIBUSB="$BUILD_DIR/$LIBUSB"/release
 
+wget "$WINDOWSBINMODE_URL" -O binmode.cwget
+
 if [ "$ARCH" == "darwin" ]; then
   # TODO
   $CC -o hidtest hidtest.cpp -lusb-1.0 -I../hidtest
 else
-  $CC -o "icesprog$EXE" icesprog.c -static -L"$PREFIX_LIBHIDAPI"/lib -I"$PREFIX_LIBHIDAPI"/include/hidapi -l$LIBHIDAPI_NAME -L"$PREFIX_LIBUSB"/lib -lusb-1.0 -lpthread -I"$PREFIX_LIBUSB"/include/libusb-1.0 $EXTRA_LIB
+  $CC -o "icesprog$EXE" icesprog.c binmode.c -static -L"$PREFIX_LIBHIDAPI"/lib -I"$PREFIX_LIBHIDAPI"/include/hidapi -l$LIBHIDAPI_NAME -L"$PREFIX_LIBUSB"/lib -lusb-1.0 -lpthread -I"$PREFIX_LIBUSB"/include/libusb-1.0 $EXTRA_LIB
  
 fi
-#elif [ "${ARCH:0:7}" == "windows" ]; then
-
-  # windows libc converts line ending by default. This is a workarround.
-#  echo -e "#if (defined _WIN32 || defined WIN32) && ! defined CYGWIN
-  #include <fcntl.h>
-#  int _fmode = _O_BINARY;
-  #endif" > binmode.c
-
-#  $CC -o "icesprog$EXE" icesprog.c binmode.c -static -L"$BUILD_DIR/$LIBHIDAPI2"/release/lib -I"$BUILD_DIR/$LIBHIDAPI2"/release/include/hidapi -lhidapi -L"$BUILD_DIR/$LIBUSB"/release/lib -I"$BUILD_DIR/$LIBUSB"/release/include/libusb-1.0 -lusb-1.0 -lpthread -lsetupapi
 
 cd ..
 

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -26,7 +26,7 @@ fi
 
 if [ "${ARCH:0:7}" == "windows" ]; then
   sudo apt-get install -y build-essential cmake pkg-config \
-                          mingw-w64 mingw-w64-tools
+                          mingw-w64 mingw-w64-tools autoconf libtool
   sudo apt-get autoremove -y
 fi
 

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -7,7 +7,7 @@ if [ "$ARCH" == "linux_x86_64" ]; then
 fi
 
 if [ "$ARCH" == "linux_i686" ]; then
-  sudo apt-get install -y build-essential cmake pkg-config \
+  sudo apt-get install -y build-essential cmake pkg-config libudev-dev:i386 libusb-1.0-0-dev:i386 libfox-1.6-dev autotools-dev autoconf automake libtool \
                           gcc-multilib g++-multilib
   sudo apt-get autoremove -y
 fi


### PR DESCRIPTION
This fixes:
- Missing dependencies on some platforms.
- Windows binary mode. (now hosted on another repo)
- linux_i686 CONFIG_FLAGS break compilation and are not needed (As far as I can see).
